### PR TITLE
Handle 'Use of uninitialized value' warning in RequestsDelete.pm

### DIFF
--- a/Kernel/System/Console/Command/Maint/Survey/RequestsDelete.pm
+++ b/Kernel/System/Console/Command/Maint/Survey/RequestsDelete.pm
@@ -137,6 +137,9 @@ sub Run {
             # fetch the result
             while ( my @Row = $DBObject->FetchrowArray() ) {
 
+                # vote time can be null
+                $Row[3] = $Row[3] || "-";
+
                 my $Result = join(
                     ' ', "Survey:" . $Row[0] . "\t",
                     "TicketNumber:" . $Row[1] . "\t",

--- a/Survey.sopm
+++ b/Survey.sopm
@@ -2,7 +2,7 @@
 <otobo_package version="1.0">
     <Name>Survey</Name>
     <Version>0.0.0</Version>
-    <Framework>10.0.x</Framework>
+    <Framework>10.1.x</Framework>
     <Vendor>Rother OSS GmbH</Vendor>
     <URL>https://otobo.de/</URL>
     <License>GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007</License>

--- a/i18n/Survey/Survey.ar_SA.po
+++ b/i18n/Survey/Survey.ar_SA.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ar_SA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.bg.po
+++ b/i18n/Survey/Survey.bg.po
@@ -2,13 +2,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Survey\n"
 "POT-Creation-Date: 2020-01-24 14:38+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2022-12-14 11:48+0000\n"
+"Last-Translator: Yasen Arsov <jarsov@gmail.com>\n"
+"Language-Team: Bulgarian <https://translate.otobo.org/projects/otobo10/"
+"survey/bg/>\n"
+"Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.4.2\n"
 
 #. Template: AgentSurveyAdd
 msgid "Create New Survey"
@@ -36,19 +39,19 @@ msgstr "Вътрешно описание"
 
 #. Template: AgentSurveyAdd
 msgid "Customer conditions"
-msgstr ""
+msgstr "Клиентски условия"
 
 #. Template: AgentSurveyAdd
 msgid "Please choose a Customer property to add a condition."
-msgstr ""
+msgstr "Моля, изберете свойство на клиента, за да добавите условие."
 
 #. Template: AgentSurveyAdd
 msgid "Public survey key"
-msgstr ""
+msgstr "Ключ за обществено проучване"
 
 #. Template: AgentSurveyAdd
 msgid "Example survey"
-msgstr ""
+msgstr "Примерна анкета"
 
 #. Template: AgentSurveyEdit
 msgid "Edit General Info"
@@ -96,7 +99,7 @@ msgstr "Когато приключите с редактирането на в�
 
 #. Template: AgentSurveyEditQuestions
 msgid "Close this window"
-msgstr ""
+msgstr "Затворете този прозорец"
 
 #. Template: AgentSurveyEditQuestions
 msgid "Edit Question"
@@ -136,27 +139,30 @@ msgstr "Върнете се, за да редактирате въпроса"
 
 #. Template: AgentSurveyEditQuestions
 msgid "Answer:"
-msgstr "Отговор"
+msgstr "Отговор:"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Survey overview options"
-msgstr ""
+msgstr "Опции за преглед на проучването"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
 msgstr ""
+"Търси в атрибутите Number, Title, Introduction, Description, "
+"NotificationSender, NotificationSubject и NotificationBody, заменяйки други "
+"атрибути със същото име."
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Survey Create Time"
-msgstr ""
+msgstr "Време за създаване на анкета"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "No restriction"
-msgstr ""
+msgstr "Без ограничение"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Only surveys created between"
-msgstr ""
+msgstr "Само анкети, създадени между"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Max. shown surveys per page"
@@ -184,7 +190,7 @@ msgstr "Таблица с исканията"
 
 #. Template: AgentSurveyStats
 msgid "Select all requests"
-msgstr ""
+msgstr "Изберете всички заявки"
 
 #. Template: AgentSurveyStats
 msgid "Send Time"
@@ -196,7 +202,7 @@ msgstr "Време за гласуване"
 
 #. Template: AgentSurveyStats
 msgid "Select this request"
-msgstr ""
+msgstr "Изберете тази заявка"
 
 #. Template: AgentSurveyStats
 msgid "See Details"
@@ -204,7 +210,7 @@ msgstr "Детайли"
 
 #. Template: AgentSurveyStats
 msgid "Delete stats"
-msgstr ""
+msgstr "Изтриване на статистика"
 
 #. Template: AgentSurveyStats
 msgid "Survey Stat Details"
@@ -216,11 +222,11 @@ msgstr "Върнете се към общия преглед на статист
 
 #. Template: AgentSurveyStats
 msgid "Previous vote"
-msgstr ""
+msgstr "Предишно гласуване"
 
 #. Template: AgentSurveyStats
 msgid "Next vote"
-msgstr ""
+msgstr "Следващ вот"
 
 #. Template: AgentSurveyZoom
 msgid "Survey Information"
@@ -248,7 +254,7 @@ msgstr "Графика на резултатите от изследването
 
 #. Template: AgentSurveyZoom
 msgid "No stat results."
-msgstr "Няма статически резултати"
+msgstr "Няма статически резултати."
 
 #. Template: PublicSurvey
 msgid "Survey"
@@ -312,7 +318,7 @@ msgstr "Квадратче за отметка (списък)"
 
 #. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
 msgid "Net Promoter Score"
-msgstr ""
+msgstr "Нетен резултат на промоутъра"
 
 #. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
 msgid "Question Type"
@@ -376,7 +382,7 @@ msgstr "- Промяна на състоянието -"
 
 #. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
 msgid "Master"
-msgstr ""
+msgstr "Главен"
 
 #. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
 msgid "Invalid"
@@ -408,7 +414,7 @@ msgstr "Проучването приключи."
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Survey Message!"
-msgstr "Съобщение"
+msgstr "Съобщение!"
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Module not enabled."
@@ -420,7 +426,7 @@ msgstr "Тази функция не е активирана, моля, свър
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Survey Error!"
-msgstr "Грешка"
+msgstr "Грешка!"
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Invalid survey key."
@@ -444,7 +450,7 @@ msgstr "Вие вече сте отговорили."
 
 #. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
 msgid "Survey List"
-msgstr ""
+msgstr "Списък с анкети"
 
 #. JS File: Survey.Agent.SurveyEditQuestions
 msgid "Do you really want to delete this question? ALL associated data will be LOST!"
@@ -489,10 +495,14 @@ msgstr "Модул за преглед, за да покаже изглед на
 #. SysConfig
 msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
 msgstr ""
+"Определя групи, които имат разрешение да променят статуса на проучването. "
+"Масивът е празен по подразбиране и агентите от всички групи могат да "
+"променят статуса на проучването."
 
 #. SysConfig
 msgid "Defines if survey requests will be only send to real customers."
 msgstr ""
+"Определя дали заявките за проучвания ще се изпращат само до реални клиенти."
 
 #. SysConfig
 msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
@@ -505,6 +515,8 @@ msgstr "Сумата в часове, за която билетът трябв�
 #. SysConfig
 msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
 msgstr ""
+"Дефинира колоните за падащия списък за изграждане на условия за изпращане (0 "
+"=> неактивно, 1 => активно)."
 
 #. SysConfig
 msgid "Defines the default height for Richtext views for SurveyZoom elements."
@@ -513,6 +525,8 @@ msgstr "Височината по подразбиране за изгледа �
 #. SysConfig
 msgid "Defines the groups (rw) which can delete survey stats."
 msgstr ""
+"Дефинира групите (rw), които могат да изтриват статистически данни от "
+"проучването."
 
 #. SysConfig
 msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
@@ -525,6 +539,7 @@ msgstr "Колоните за показване в общия преглед н
 #. SysConfig
 msgid "Determines if the statistics module may generate survey lists."
 msgstr ""
+"Определя дали статистическият модул може да генерира списъци с проучвания."
 
 #. SysConfig
 msgid "Edit survey general information."
@@ -572,7 +587,7 @@ msgstr "Ако този регекс съвпада, няма да бъде из
 
 #. SysConfig
 msgid "Limit."
-msgstr ""
+msgstr "Лимит."
 
 #. SysConfig
 msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
@@ -585,6 +600,9 @@ msgstr "Публично проучване."
 #. SysConfig
 msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
 msgstr ""
+"Резултати, по-стари от конфигурирания брой дни, ще бъдат изтрити. Забележка: "
+"изтрийте резултатите, направени от OTOBO Daemon, преди активиране на "
+"настройката „Task###SurveyRequestsDelete“."
 
 #. SysConfig
 msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
@@ -645,6 +663,7 @@ msgstr "Модул за събитие на билети за автоматич
 #. SysConfig
 msgid "Trigger delete results (including vote data and requests)."
 msgstr ""
+"Задействайте изтрити резултати (включително данни за гласуване и заявки)."
 
 #. SysConfig
 msgid "Trigger sending delayed survey requests."
@@ -653,4 +672,3 @@ msgstr "Trigger изпраща закъснели заявки за проучв
 #. SysConfig
 msgid "Zoom into statistics details."
 msgstr "Увеличете статистическите данни."
-

--- a/i18n/Survey/Survey.ca.po
+++ b/i18n/Survey/Survey.ca.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.en_CA.po
+++ b/i18n/Survey/Survey.en_CA.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.es_CO.po
+++ b/i18n/Survey/Survey.es_CO.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es_CO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.et.po
+++ b/i18n/Survey/Survey.et.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: et\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.fi.po
+++ b/i18n/Survey/Survey.fi.po
@@ -2,13 +2,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Survey\n"
 "POT-Creation-Date: 2020-01-24 14:38+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2022-12-30 13:30+0000\n"
+"Last-Translator: Markus Hynnä <markus.hynna@mynamaki.fi>\n"
+"Language-Team: Finnish <https://translate.otobo.org/projects/otobo10/survey/"
+"fi/>\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.4.2\n"
 
 #. Template: AgentSurveyAdd
 msgid "Create New Survey"
@@ -348,7 +351,7 @@ msgstr "Yksityiskohtaiset tulokset"
 
 #. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
 msgid "Can't set new status! No questions defined."
-msgstr "Uuden tilan asettaminen ei onnistu! Et ole määrittänyt kysymyksiä!"
+msgstr "Uuden tilan asettaminen ei onnistu! Et ole määrittänyt kysymyksiä."
 
 #. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
 msgid "Can't set new status! Questions incomplete."
@@ -460,7 +463,7 @@ msgstr "Kyselyominaisuus"
 
 #. SysConfig
 msgid "A module to edit survey questions."
-msgstr "Moduuli kyselyiden luontiin"
+msgstr "Moduuli kyselyiden luontiin."
 
 #. SysConfig
 msgid "All parameters for the Survey object in the agent interface."
@@ -653,4 +656,3 @@ msgstr ""
 #. SysConfig
 msgid "Zoom into statistics details."
 msgstr ""
-

--- a/i18n/Survey/Survey.fr_CA.po
+++ b/i18n/Survey/Survey.fr_CA.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.he.po
+++ b/i18n/Survey/Survey.he.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.hi.po
+++ b/i18n/Survey/Survey.hi.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.ja.po
+++ b/i18n/Survey/Survey.ja.po
@@ -2,13 +2,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Survey\n"
 "POT-Creation-Date: 2020-01-24 14:38+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2023-08-25 02:32+0000\n"
+"Last-Translator: Kozo Sakurai <sakurai@io-architect.com>\n"
+"Language-Team: Japanese <https://translate.otobo.org/projects/otobo10/survey/"
+"ja/>\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.4.2\n"
 
 #. Template: AgentSurveyAdd
 msgid "Create New Survey"
@@ -120,7 +123,7 @@ msgstr "回答の追加"
 
 #. Template: AgentSurveyEditQuestions
 msgid "No answers saved for this question."
-msgstr "この質問への回答はまだありません"
+msgstr "この質問への回答はまだありません。"
 
 #. Template: AgentSurveyEditQuestions
 msgid "This doesn't have several answers, a textarea will be displayed."
@@ -536,7 +539,8 @@ msgstr "アンケートの質問を修正"
 
 #. SysConfig
 msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
-msgstr "公開インターフェースにおいて、顧客が2度回答しようとした際に、これまでの回答データを表示するShowVoteData画面を有効にするか否か"
+msgstr ""
+"公開インターフェースにおいて、顧客が2度回答しようとした際に、これまでの回答データを表示するShowVoteData画面を有効にするか否かを設定します。"
 
 #. SysConfig
 msgid "Enable or disable the send condition check for the service."
@@ -653,4 +657,3 @@ msgstr "追ってのアンケート要求を送信するトリガ"
 #. SysConfig
 msgid "Zoom into statistics details."
 msgstr "統計情報の詳細をズームインする。"
-

--- a/i18n/Survey/Survey.ko.po
+++ b/i18n/Survey/Survey.ko.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.lt.po
+++ b/i18n/Survey/Survey.lt.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.lv.po
+++ b/i18n/Survey/Survey.lv.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.ru.po
+++ b/i18n/Survey/Survey.ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Survey\n"
 "POT-Creation-Date: 2020-01-24 14:38+0000\n"
-"PO-Revision-Date: 2022-05-27 03:10+0000\n"
+"PO-Revision-Date: 2022-06-09 09:26+0000\n"
 "Last-Translator: Philipp Kesler <philipp.kesler@hein.de>\n"
 "Language-Team: Russian <https://translate.otobo.org/projects/otobo10/survey/"
 "ru/>\n"
@@ -20,7 +20,7 @@ msgstr "Создать новый опрос"
 
 #. Template: AgentSurveyAdd
 msgid "Introduction"
-msgstr "Описание"
+msgstr "Введение"
 
 #. Template: AgentSurveyAdd
 msgid "Survey Introduction"
@@ -144,23 +144,26 @@ msgstr "Ответ:"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Survey overview options"
-msgstr ""
+msgstr "Параметры обзора опроса"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
 msgstr ""
+"Выполняет поиск в атрибутах Number, Title, Introduction, Description, "
+"NotificationSender, NotificationSubject и NotificationBody, переопределяя "
+"другие атрибуты с тем же именем."
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Survey Create Time"
-msgstr ""
+msgstr "Время создания опроса"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "No restriction"
-msgstr ""
+msgstr "Без ограничений"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Only surveys created between"
-msgstr ""
+msgstr "Только опросы, созданные между"
 
 #. Template: AgentSurveyOverviewNavBar
 msgid "Max. shown surveys per page"
@@ -188,7 +191,7 @@ msgstr "Таблица ответов"
 
 #. Template: AgentSurveyStats
 msgid "Select all requests"
-msgstr ""
+msgstr "Выберите все запросы"
 
 #. Template: AgentSurveyStats
 msgid "Send Time"
@@ -200,7 +203,7 @@ msgstr "Время ответа"
 
 #. Template: AgentSurveyStats
 msgid "Select this request"
-msgstr ""
+msgstr "Выберите этот запрос"
 
 #. Template: AgentSurveyStats
 msgid "See Details"
@@ -208,7 +211,7 @@ msgstr "См. подробности"
 
 #. Template: AgentSurveyStats
 msgid "Delete stats"
-msgstr ""
+msgstr "Удалить статистику"
 
 #. Template: AgentSurveyStats
 msgid "Survey Stat Details"
@@ -220,11 +223,11 @@ msgstr "назад"
 
 #. Template: AgentSurveyStats
 msgid "Previous vote"
-msgstr ""
+msgstr "Предыдущее голосование"
 
 #. Template: AgentSurveyStats
 msgid "Next vote"
-msgstr ""
+msgstr "Следующее голосование"
 
 #. Template: AgentSurveyZoom
 msgid "Survey Information"
@@ -284,7 +287,7 @@ msgstr "У вас нет разрешения для этого опроса!"
 
 #. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
 msgid "No SurveyID is given!"
-msgstr ""
+msgstr "Идентификатор опроса не предоставляется!"
 
 #. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
 msgid "Survey Edit"
@@ -316,7 +319,7 @@ msgstr "Галочки (Список)"
 
 #. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
 msgid "Net Promoter Score"
-msgstr ""
+msgstr "индекс лояльности клиентов"
 
 #. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
 msgid "Question Type"

--- a/i18n/Survey/Survey.ru.po
+++ b/i18n/Survey/Survey.ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Survey\n"
 "POT-Creation-Date: 2020-01-24 14:38+0000\n"
-"PO-Revision-Date: 2022-06-09 09:26+0000\n"
+"PO-Revision-Date: 2022-06-10 02:54+0000\n"
 "Last-Translator: Philipp Kesler <philipp.kesler@hein.de>\n"
 "Language-Team: Russian <https://translate.otobo.org/projects/otobo10/survey/"
 "ru/>\n"
@@ -415,7 +415,7 @@ msgstr "Опрос завершен."
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Survey Message!"
-msgstr ""
+msgstr "Сообщение об опросе!"
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Module not enabled."
@@ -423,11 +423,11 @@ msgstr "Модуль не включен"
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "This functionality is not enabled, please contact your administrator."
-msgstr ""
+msgstr "Эта функция не включена, обратитесь к администратору."
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Survey Error!"
-msgstr ""
+msgstr "Ошибка опроса!"
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Invalid survey key."
@@ -436,14 +436,16 @@ msgstr "Неверный код опроса"
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
 msgstr ""
+"Введенный ключ опроса недействителен, если вы перешли по ссылке, возможно, "
+"она устарела или сломана."
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Survey Vote"
-msgstr ""
+msgstr "Голосование по опросу"
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "Survey Vote Data"
-msgstr ""
+msgstr "Данные голосования по опросу"
 
 #. Perl Module: Kernel/Modules/PublicSurvey.pm
 msgid "You have already answered the survey."
@@ -451,7 +453,7 @@ msgstr "Вы уже прошли опрос."
 
 #. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
 msgid "Survey List"
-msgstr ""
+msgstr "Список опросов"
 
 #. JS File: Survey.Agent.SurveyEditQuestions
 msgid "Do you really want to delete this question? ALL associated data will be LOST!"
@@ -496,10 +498,14 @@ msgstr "Задает модуль просмотра для отображени
 #. SysConfig
 msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
 msgstr ""
+"Определяет группы, у которых есть разрешение на изменение статуса опроса. По "
+"умолчанию массив пуст, и агенты из всех групп могут изменять статус опроса."
 
 #. SysConfig
 msgid "Defines if survey requests will be only send to real customers."
 msgstr ""
+"Определяет, будут ли запросы на опрос отправляться только существующим "
+"клиентам."
 
 #. SysConfig
 msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
@@ -508,10 +514,17 @@ msgstr "Задает максимальное количество опросо�
 #. SysConfig
 msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
 msgstr ""
+"Определяет количество часов, в течение которых тикет должен быть закрыт, "
+"чтобы инициировать отправку опроса (0 означает отправку сразу после закрытия)"
+". Примечание: отложенная отправка опросов осуществляется демоном OTOBO, до "
+"активации настройки "
+"'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend'."
 
 #. SysConfig
 msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
 msgstr ""
+"Определяет столбцы выпадающего списка для построения условий отправки (0 => "
+"неактивно, 1 => активно)."
 
 #. SysConfig
 msgid "Defines the default height for Richtext views for SurveyZoom elements."
@@ -519,11 +532,13 @@ msgstr "Задает высоту по умолчанию области фор�
 
 #. SysConfig
 msgid "Defines the groups (rw) which can delete survey stats."
-msgstr ""
+msgstr "Определяет группы (rw), которые могут удалять статистику опроса."
 
 #. SysConfig
 msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
 msgstr ""
+"Определяет максимальную высоту для представлений Richtext для элементов "
+"SurveyZoom."
 
 #. SysConfig
 msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
@@ -531,11 +546,11 @@ msgstr "Задает перечень колонок, отображаемых �
 
 #. SysConfig
 msgid "Determines if the statistics module may generate survey lists."
-msgstr ""
+msgstr "Определяет, может ли модуль статистики генерировать списки опросов."
 
 #. SysConfig
 msgid "Edit survey general information."
-msgstr ""
+msgstr "Редактирование общей информации об опросе."
 
 #. SysConfig
 msgid "Edit survey questions."
@@ -592,6 +607,9 @@ msgstr "Общедоступный опрос."
 #. SysConfig
 msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
 msgstr ""
+"Результаты старше настроенного количества дней будут удалены. Примечание: "
+"удаление результатов производится демоном OTOBO Daemon, до активации "
+"настройки 'Task###SurveyRequestsDelete'."
 
 #. SysConfig
 msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
@@ -635,7 +653,7 @@ msgstr "Модуль подробного просмотра опросов."
 
 #. SysConfig
 msgid "Survey limit per page for Survey Overview \"Small\"."
-msgstr ""
+msgstr "Предел опроса на страницу для обзора опроса \" Небольшой\"."
 
 #. SysConfig
 msgid "Surveys will not be sent to the configured email addresses."

--- a/i18n/Survey/Survey.ru.po
+++ b/i18n/Survey/Survey.ru.po
@@ -2,13 +2,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Survey\n"
 "POT-Creation-Date: 2020-01-24 14:38+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2022-05-27 03:10+0000\n"
+"Last-Translator: Philipp Kesler <philipp.kesler@hein.de>\n"
+"Language-Team: Russian <https://translate.otobo.org/projects/otobo10/survey/"
+"ru/>\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Weblate 4.4.2\n"
 
 #. Template: AgentSurveyAdd
 msgid "Create New Survey"
@@ -36,19 +40,19 @@ msgstr "Внутреннее описание"
 
 #. Template: AgentSurveyAdd
 msgid "Customer conditions"
-msgstr ""
+msgstr "Условия для клиентов"
 
 #. Template: AgentSurveyAdd
 msgid "Please choose a Customer property to add a condition."
-msgstr ""
+msgstr "Выберите <Свойство клиента>, чтобы добавить условие."
 
 #. Template: AgentSurveyAdd
 msgid "Public survey key"
-msgstr ""
+msgstr "Открытый ключ опроса"
 
 #. Template: AgentSurveyAdd
 msgid "Example survey"
-msgstr ""
+msgstr "Пример опроса"
 
 #. Template: AgentSurveyEdit
 msgid "Edit General Info"
@@ -644,7 +648,7 @@ msgstr "Модуль управления событием для заявки, 
 
 #. SysConfig
 msgid "Trigger delete results (including vote data and requests)."
-msgstr ""
+msgstr "Триггер удаления результатов (включая данные голосования и запросы)."
 
 #. SysConfig
 msgid "Trigger sending delayed survey requests."
@@ -652,5 +656,4 @@ msgstr "Триггер отправки задержанных запросов 
 
 #. SysConfig
 msgid "Zoom into statistics details."
-msgstr ""
-
+msgstr "Масштабировать детали статистики."

--- a/i18n/Survey/Survey.si.po
+++ b/i18n/Survey/Survey.si.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: si\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.sk.po
+++ b/i18n/Survey/Survey.sk.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""

--- a/i18n/Survey/Survey.tr.po
+++ b/i18n/Survey/Survey.tr.po
@@ -1,0 +1,655 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Survey\n"
+"POT-Creation-Date: 2020-01-24 14:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. Template: AgentSurveyAdd
+msgid "Create New Survey"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Survey Introduction"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Notification Body"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Ticket Types"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Internal Description"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Customer conditions"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Please choose a Customer property to add a condition."
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Public survey key"
+msgstr ""
+
+#. Template: AgentSurveyAdd
+msgid "Example survey"
+msgstr ""
+
+#. Template: AgentSurveyEdit
+msgid "Edit General Info"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "You are here"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Survey Questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Type the question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No questions saved for this survey."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer Required"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "When you finish to edit the survey questions just close this screen."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Close this window"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to questions"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Question:"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Possible Answers For"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Add Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "No answers saved for this question."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "This doesn't have several answers, a textarea will be displayed."
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Edit Answer"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "go back to edit question"
+msgstr ""
+
+#. Template: AgentSurveyEditQuestions
+msgid "Answer:"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey overview options"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Searches in the attributes Number, Title, Introduction, Description, NotificationSender, NotificationSubject and NotificationBody, overriding other attributes with the same name."
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Survey Create Time"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "No restriction"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Only surveys created between"
+msgstr ""
+
+#. Template: AgentSurveyOverviewNavBar
+msgid "Max. shown surveys per page"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Sender"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Notification Subject"
+msgstr ""
+
+#. Template: AgentSurveyOverviewSmall
+msgid "Changed By"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Stats Overview of"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Requests Table"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select all requests"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Send Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Vote Time"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Select this request"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "See Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Delete stats"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Survey Stat Details"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "go back to stats overview"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Previous vote"
+msgstr ""
+
+#. Template: AgentSurveyStats
+msgid "Next vote"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Information"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Sent requests"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Received surveys"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Details"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Ticket Services"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "Survey Results Graph"
+msgstr ""
+
+#. Template: AgentSurveyZoom
+msgid "No stat results."
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Please answer these questions"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Show my answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "These are your answers"
+msgstr ""
+
+#. Template: PublicSurvey
+msgid "Survey Title"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyAdd.pm
+msgid "Add New Survey"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "You have no permission for this survey!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "No SurveyID is given!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEdit.pm
+msgid "Survey Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey or question!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "You have no permission for this survey, question or answer!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Survey Edit Questions"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Yes/No"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Radio (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Checkbox (List)"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Net Promoter Score"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Type"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Complete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Incomplete"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Question Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyEditQuestions.pm
+msgid "Answer Edit"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Overview"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "You have no permission for this survey or stats detail!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyStats.pm
+msgid "Stats Detail"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! No questions defined."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Can't set new status! Questions incomplete."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Status changed."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No queue selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket type selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- No ticket service selected -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "- Change Status -"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Master"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Invalid"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "New Status"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "Survey Description"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/AgentSurveyZoom.pm
+msgid "not answered"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Thank you for your feedback."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The survey is finished."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Message!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Module not enabled."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "This functionality is not enabled, please contact your administrator."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Error!"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Invalid survey key."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "The inserted survey key is invalid, if you followed a link maybe this is obsolete or broken."
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "Survey Vote Data"
+msgstr ""
+
+#. Perl Module: Kernel/Modules/PublicSurvey.pm
+msgid "You have already answered the survey."
+msgstr ""
+
+#. Perl Module: Kernel/System/Stats/Dynamic/SurveyList.pm
+msgid "Survey List"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this question? ALL associated data will be LOST!"
+msgstr ""
+
+#. JS File: Survey.Agent.SurveyEditQuestions
+msgid "Do you really want to delete this answer?"
+msgstr ""
+
+#. SysConfig
+msgid "A Survey Module."
+msgstr ""
+
+#. SysConfig
+msgid "A module to edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "All parameters for the Survey object in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Amount of days after sending a survey mail in which no new survey requests are sent to the same customer. Selecting 0 will always send the survey mail."
+msgstr ""
+
+#. SysConfig
+msgid "Default body for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default sender for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Default subject for the notification email to customers about new survey."
+msgstr ""
+
+#. SysConfig
+msgid "Defines an overview module to show the small view of a survey list."
+msgstr ""
+
+#. SysConfig
+msgid "Defines groups which have a permission to change survey status. Array is empty by default and agents from all groups can change survey status."
+msgstr ""
+
+#. SysConfig
+msgid "Defines if survey requests will be only send to real customers."
+msgstr ""
+
+#. SysConfig
+msgid "Defines maximum amount of surveys that get sent to a customer per 30 days. ( 0 means no maximum, all survey requests will be sent)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the amount in hours a ticket has to be closed to trigger the sending of a survey, ( 0 means send immediately after close ). Note: delayed survey sending is done by the OTOBO Daemon, prior activation of 'Daemon::SchedulerCronTaskManager::Task###SurveyRequestsSend' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the columns for the dropdown list for building send conditions (0 => inactive, 1 => active)."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the default height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the groups (rw) which can delete survey stats."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the maximum height for Richtext views for SurveyZoom elements."
+msgstr ""
+
+#. SysConfig
+msgid "Defines the shown columns in the survey overview. This option has no effect on the position of the columns."
+msgstr ""
+
+#. SysConfig
+msgid "Determines if the statistics module may generate survey lists."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey general information."
+msgstr ""
+
+#. SysConfig
+msgid "Edit survey questions."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the ShowVoteData screen in the public interface to show data of a specific survey result when the customer tries to answer a survey the second time."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the service."
+msgstr ""
+
+#. SysConfig
+msgid "Enable or disable the send condition check for the ticket type."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey add in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey edit in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey stats in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for survey zoom in the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Frontend module registration for the PublicSurvey object in the public Survey area."
+msgstr ""
+
+#. SysConfig
+msgid "If this regex matches, no customer survey will be sent."
+msgstr ""
+
+#. SysConfig
+msgid "Limit."
+msgstr ""
+
+#. SysConfig
+msgid "Parameters for the pages (in which the surveys are shown) of the small survey overview."
+msgstr ""
+
+#. SysConfig
+msgid "Public Survey."
+msgstr ""
+
+#. SysConfig
+msgid "Results older than the configured amount of days will be deleted. Note: delete results done by the OTOBO Daemon, prior activation of 'Task###SurveyRequestsDelete' setting."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit a survey in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to edit survey questions in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to go back in the survey zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Shows a link in the menu to zoom into the survey statistics details in its zoom view of the agent interface."
+msgstr ""
+
+#. SysConfig
+msgid "Stats Details"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Add Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Edit Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Overview \"Small\" Limit"
+msgstr ""
+
+#. SysConfig
+msgid "Survey Stats Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey Zoom Module."
+msgstr ""
+
+#. SysConfig
+msgid "Survey limit per page for Survey Overview \"Small\"."
+msgstr ""
+
+#. SysConfig
+msgid "Surveys will not be sent to the configured email addresses."
+msgstr ""
+
+#. SysConfig
+msgid "The identifier for a survey, e.g. Survey#, MySurvey#. The default is Survey#."
+msgstr ""
+
+#. SysConfig
+msgid "Ticket event module to send automatically survey email requests to customers if a ticket is closed."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger delete results (including vote data and requests)."
+msgstr ""
+
+#. SysConfig
+msgid "Trigger sending delayed survey requests."
+msgstr ""
+
+#. SysConfig
+msgid "Zoom into statistics details."
+msgstr ""


### PR DESCRIPTION
When deleting a survey request that has no vote time set, the following warning is shown.

`Use of uninitialized value $Row[3] in concatenation (.) or string at /opt/otobo/Kernel/System/Console/Command/Maint/Survey/RequestsDelete.pm line 140.`

$Row[3] is null if no vote time is set in the database. If that is the case we can set it to '-' for example, to avoid the message.

On manual execution (via otobo.Console.pl) the message is shown on the command line. On automatic execution (via SchedulerCronTaskManager) an email is generated.

![grafik](https://github.com/RotherOSS/Survey/assets/84456263/8727e7db-555d-40d4-9e5d-84efd127c29b)
